### PR TITLE
fix: `set_reference_path` fails because clcs_params is None

### DIFF
--- a/commonroad_rp/utility/utils_coordinate_system.py
+++ b/commonroad_rp/utility/utils_coordinate_system.py
@@ -51,6 +51,8 @@ class CoordinateSystem(CurvilinearCoordinateSystem):
         :params clcs_params: CLCS parameters
                 - if None: The default clcs parameters are taken (see commonroad_clcs.config for details)
         """
+        if clcs_params is None:
+            clcs_params = CLCSParams()
 
         super().__init__(
             reference_path=reference,


### PR DESCRIPTION
`set_reference_path` constructs a `CoordinateSystem` from the given reference path. The `CoordinateSystem` uses `None` as default `CLCSParams`, which is not supported by `CurvilinearCoordinateSystem`.